### PR TITLE
fix: show the main window by attaching ready-to-show before load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed the main window never appearing when the renderer paints before `loadURL` resolves; the `ready-to-show` listener is now attached before loading.
+
 ## 0.8.2 — public preview
 
 - Publish only end-user installers from release jobs, excluding unpacked build directories.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,13 +33,14 @@ async function createWindow(): Promise<BrowserWindow> {
     if (currentUrl && url !== currentUrl) event.preventDefault();
   });
 
+  window.once("ready-to-show", () => window.show());
+
   if (process.env.ELECTRON_RENDERER_URL) {
     await window.loadURL(process.env.ELECTRON_RENDERER_URL);
   } else {
     await window.loadFile(join(__dirname, "../renderer/index.html"));
   }
 
-  window.once("ready-to-show", () => window.show());
   window.on("closed", () => {
     if (mainWindow === window) mainWindow = null;
   });


### PR DESCRIPTION
Fixes #1.

`createWindow()` awaited `loadURL()` before attaching the `ready-to-show` listener. On fast machines the renderer paints first, the event fires while the promise is still pending, and the listener attached afterwards never runs — so the window stays hidden forever while the Dock icon looks alive.

The listener is now attached before the load starts. Verified on macOS 15 (Apple Silicon): the window appears reliably, `npm test` (34 tests) and `npm run typecheck` pass.