### PR TITLE
docs: add Spanish, German, French, Japanese, Korean, Portuguese READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,64 @@
+<p align="center">
+  <img src="docs/assets/canvastty-cover.png" alt="CanvasTTY — ein räumlicher Desktop für lokale Terminals und KI-Agenten" width="100%">
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md"><strong>Deutsch</strong></a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.pt-BR.md">Português</a> ·
+  <a href="README.ru.md">Русский</a> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<table>
+  <tr>
+    <td>
+      <strong>Ihre Terminals sind Orte, keine Tabs.</strong><br>
+      CanvasTTY ist ein räumlicher Electron-Desktop für echte lokale PTYs und CLI-Sitzungen von KI-Agenten. Feste Home-Zone, Live-Terminals auf einer unendlichen Fläche und Provider-Limits aus realen Datenquellen.
+    </td>
+  </tr>
+</table>
+
+## Stack
+
+| Desktop | Oberfläche | Terminal | Provider |
+|:--|:--|:--|:--|
+| **Electron**<br>electron-vite | **React**<br>TypeScript | **xterm.js**<br>node-pty | **Codex**<br>Claude · Kimi |
+
+## Eine Fläche, echte Sitzungen
+
+Starten Sie eine Shell oder einen Agenten im Projektverzeichnis, verschieben und skalieren Sie das Live-Terminal, zoomen Sie heraus zur semantischen Navigation und kehren Sie zu Home zurück — zu Sitzungen, Limits, Medien und Start-Shortcuts. CanvasTTY hält den PTY-Zustand im vertrauenswürdigen Main-Prozess und gibt dem Renderer nur typisierte, freigegebene Fähigkeiten frei.
+
+## Installation
+
+Laden Sie die öffentliche Vorschau `0.9.x` von [GitHub Releases](https://github.com/howdeploy/CanvasTTY/releases): AppImage/deb für Linux x86_64, Installer/portable App für Windows x64 und dmg/zip für Apple-Silicon-macOS. Pakete sind noch nicht code-signiert oder notarisiert; Intel-Mac-Builds fehlen vorerst. Siehe [Installation und lokale Datensicherheit](docs/installing-and-security.md).
+
+Oder aus dem Quellcode starten:
+
+```bash
+npm install
+npm run dev
+```
+
+## Dokumentation
+
+| Hier starten | CanvasTTY erweitern |
+|:--|:--|
+| [Dokumentations-Hub](docs/README.md) | [Widget-Authoring](docs/widget-authoring.md) |
+| [Erste Schritte](docs/getting-started.md) | [Metriken und Telemetrie](docs/metrics-and-telemetry.md) |
+| [Installation, Releases und lokale Daten](docs/installing-and-security.md) | [Sicherheitsrichtlinie](SECURITY.md) |
+| [Architektur](docs/ARCHITECTURE.md) | [UI-Vertrag](docs/UI_CONTRACT.md) |
+
+> CanvasTTY ist derzeit ein Electron-MVP. Eigene Widgets sind Erweiterungen auf Quellcode-Ebene; ein Runtime-Plugin-Registry gibt es noch nicht.
+
+## Schnellchecks
+
+```bash
+npm test
+npm run typecheck
+npm run build
+```

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,64 @@
+<p align="center">
+  <img src="docs/assets/canvastty-cover.png" alt="CanvasTTY — un escritorio espacial para terminales locales y agentes de IA" width="100%">
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md"><strong>Español</strong></a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.pt-BR.md">Português</a> ·
+  <a href="README.ru.md">Русский</a> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<table>
+  <tr>
+    <td>
+      <strong>Tus terminales son lugares, no pestañas.</strong><br>
+      CanvasTTY es un escritorio espacial en Electron para PTY locales reales y sesiones CLI de agentes de IA. Mantén una zona Home fija, organiza terminales en vivo sobre un lienzo infinito y consulta los límites de los proveedores con datos reales.
+    </td>
+  </tr>
+</table>
+
+## Stack
+
+| Escritorio | Interfaz | Terminal | Proveedores |
+|:--|:--|:--|:--|
+| **Electron**<br>electron-vite | **React**<br>TypeScript | **xterm.js**<br>node-pty | **Codex**<br>Claude · Kimi |
+
+## Un lienzo, sesiones reales
+
+Lanza un shell o un agente en el directorio de un proyecto, mueve y redimensiona su terminal en vivo, aléjate para navegar de forma semántica y vuelve a Home para sesiones, límites, medios y accesos de lanzamiento. CanvasTTY mantiene el estado del PTY en el proceso main de confianza y expone al renderer solo capacidades tipadas y en lista blanca.
+
+## Instalación
+
+Descarga la vista previa pública `0.9.x` desde [GitHub Releases](https://github.com/howdeploy/CanvasTTY/releases): AppImage/deb para Linux x86_64, instalador/portable para Windows x64 y dmg/zip para macOS Apple Silicon. Los paquetes aún no están firmados ni notarizados; las builds para Intel Mac no se incluyen por ahora. Lee [instalación y seguridad de datos locales](docs/installing-and-security.md).
+
+O ejecuta desde el código fuente:
+
+```bash
+npm install
+npm run dev
+```
+
+## Documentación
+
+| Empieza aquí | Extiende CanvasTTY |
+|:--|:--|
+| [Centro de documentación](docs/README.md) | [Creación de widgets](docs/widget-authoring.md) |
+| [Primeros pasos](docs/getting-started.md) | [Métricas y telemetría](docs/metrics-and-telemetry.md) |
+| [Instalación, releases y datos locales](docs/installing-and-security.md) | [Política de seguridad](SECURITY.md) |
+| [Arquitectura](docs/ARCHITECTURE.md) | [Contrato de UI](docs/UI_CONTRACT.md) |
+
+> CanvasTTY es actualmente un MVP de Electron. Los widgets personalizados son extensiones a nivel de código fuente; aún no hay un registro de plugins en runtime.
+
+## Comprobaciones rápidas
+
+```bash
+npm test
+npm run typecheck
+npm run build
+```

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,64 @@
+<p align="center">
+  <img src="docs/assets/canvastty-cover.png" alt="CanvasTTY — un bureau spatial pour terminaux locaux et agents d’IA" width="100%">
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.fr.md"><strong>Français</strong></a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.pt-BR.md">Português</a> ·
+  <a href="README.ru.md">Русский</a> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<table>
+  <tr>
+    <td>
+      <strong>Vos terminaux sont des lieux, pas des onglets.</strong><br>
+      CanvasTTY est un bureau spatial Electron pour de vrais PTY locaux et des sessions CLI d’agents d’IA. Zone Home fixe, terminaux live sur un canevas infini, et quotas fournisseurs adossés à de vraies sources de données.
+    </td>
+  </tr>
+</table>
+
+## Stack
+
+| Bureau | Interface | Terminal | Fournisseurs |
+|:--|:--|:--|:--|
+| **Electron**<br>electron-vite | **React**<br>TypeScript | **xterm.js**<br>node-pty | **Codex**<br>Claude · Kimi |
+
+## Un canevas, de vraies sessions
+
+Lancez un shell ou un agent dans le dossier d’un projet, déplacez et redimensionnez le terminal live, zoomez pour une navigation sémantique, puis revenez à Home pour les sessions, quotas, médias et raccourcis de lancement. CanvasTTY garde l’état PTY dans le processus main de confiance et n’expose au renderer que des capacités typées et autorisées.
+
+## Installation
+
+Téléchargez la préversion publique `0.9.x` depuis [GitHub Releases](https://github.com/howdeploy/CanvasTTY/releases) : AppImage/deb pour Linux x86_64, installateur/portable pour Windows x64, dmg/zip pour macOS Apple Silicon. Les paquets ne sont pas encore signés ni notarisés ; les builds Intel Mac ne sont pas encore fournies. Lisez [installation et sécurité des données locales](docs/installing-and-security.md).
+
+Ou lancez depuis les sources :
+
+```bash
+npm install
+npm run dev
+```
+
+## Documentation
+
+| Commencer ici | Étendre CanvasTTY |
+|:--|:--|
+| [Hub documentation](docs/README.md) | [Création de widgets](docs/widget-authoring.md) |
+| [Premiers pas](docs/getting-started.md) | [Métriques et télémétrie](docs/metrics-and-telemetry.md) |
+| [Install, releases et données locales](docs/installing-and-security.md) | [Politique de sécurité](SECURITY.md) |
+| [Architecture](docs/ARCHITECTURE.md) | [Contrat UI](docs/UI_CONTRACT.md) |
+
+> CanvasTTY est pour l’instant un MVP Electron. Les widgets personnalisés s’ajoutent au niveau du code source ; il n’y a pas encore de registre de plugins à l’exécution.
+
+## Vérifications rapides
+
+```bash
+npm test
+npm run typecheck
+npm run build
+```

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,64 @@
+<p align="center">
+  <img src="docs/assets/canvastty-cover.png" alt="CanvasTTY — ローカル端末と AI エージェント向けの空間デスクトップ" width="100%">
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ja.md"><strong>日本語</strong></a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.pt-BR.md">Português</a> ·
+  <a href="README.ru.md">Русский</a> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<table>
+  <tr>
+    <td>
+      <strong>ターミナルはタブではなく「場所」です。</strong><br>
+      CanvasTTY は、本物のローカル PTY と AI エージェント CLI セッションのための Electron 空間デスクトップです。固定の Home ゾーン、無限キャンバス上のライブ端末、実データに基づくプロバイダ制限を備えています。
+    </td>
+  </tr>
+</table>
+
+## スタック
+
+| デスクトップ | UI | ターミナル | プロバイダ |
+|:--|:--|:--|:--|
+| **Electron**<br>electron-vite | **React**<br>TypeScript | **xterm.js**<br>node-pty | **Codex**<br>Claude · Kimi |
+
+## 1 枚のキャンバス、本物のセッション
+
+プロジェクトディレクトリでシェルやエージェントを起動し、ライブ端末を移動・リサイズ。ズームアウトして意味的に俯瞰し、Home に戻ってセッション・制限・メディア・起動ショートカットを確認できます。CanvasTTY は信頼できる main プロセスで PTY 状態を保持し、renderer には型付きの許可リスト能力のみを公開します。
+
+## インストール
+
+[GitHub Releases](https://github.com/howdeploy/CanvasTTY/releases) から公開プレビュー `0.9.x` を入手してください。Linux x86_64 は AppImage/deb、Windows x64 はインストーラ/ポータブル、Apple Silicon macOS は dmg/zip です。パッケージはまだコード署名・公証されておらず、Intel Mac ビルドは未提供です。[インストールとローカルデータのセキュリティ](docs/installing-and-security.md) を先に読んでください。
+
+ソースから実行する場合:
+
+```bash
+npm install
+npm run dev
+```
+
+## ドキュメント
+
+| まずはここから | CanvasTTY を拡張する |
+|:--|:--|
+| [ドキュメントハブ](docs/README.md) | [ウィジェット作成](docs/widget-authoring.md) |
+| [はじめに](docs/getting-started.md) | [メトリクスとテレメトリ](docs/metrics-and-telemetry.md) |
+| [インストール、リリース、ローカルデータ](docs/installing-and-security.md) | [セキュリティポリシー](SECURITY.md) |
+| [アーキテクチャ](docs/ARCHITECTURE.md) | [UI 契約](docs/UI_CONTRACT.md) |
+
+> CanvasTTY は現時点で Electron MVP です。カスタムウィジェットはソースレベルの拡張で、ランタイムのプラグインレジストリはまだありません。
+
+## クイックチェック
+
+```bash
+npm test
+npm run typecheck
+npm run build
+```

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,64 @@
+<p align="center">
+  <img src="docs/assets/canvastty-cover.png" alt="CanvasTTY — 로컬 터미널과 AI 에이전트를 위한 공간 데스크톱" width="100%">
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md"><strong>한국어</strong></a> ·
+  <a href="README.pt-BR.md">Português</a> ·
+  <a href="README.ru.md">Русский</a> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<table>
+  <tr>
+    <td>
+      <strong>터미널은 탭이 아니라 장소입니다.</strong><br>
+      CanvasTTY는 실제 로컬 PTY와 AI 에이전트 CLI 세션을 위한 Electron 공간 데스크톱입니다. 고정 Home 영역, 무한 캔버스 위의 라이브 터미널, 실제 데이터 소스 기반 프로바이더 한도를 제공합니다.
+    </td>
+  </tr>
+</table>
+
+## 스택
+
+| 데스크톱 | 인터페이스 | 터미널 | 프로바이더 |
+|:--|:--|:--|:--|
+| **Electron**<br>electron-vite | **React**<br>TypeScript | **xterm.js**<br>node-pty | **Codex**<br>Claude · Kimi |
+
+## 하나의 캔버스, 실제 세션
+
+프로젝트 디렉터리에서 셸 또는 에이전트를 실행하고, 라이브 터미널을 이동·크기 조절하세요. 축소해 의미적으로 탐색하고, Home으로 돌아와 세션·한도·미디어·실행 단축키를 확인합니다. CanvasTTY는 신뢰할 수 있는 main 프로세스에 PTY 상태를 두고, renderer에는 타입이 지정된 허용 목록 기능만 노출합니다.
+
+## 설치
+
+[GitHub Releases](https://github.com/howdeploy/CanvasTTY/releases)에서 공개 프리뷰 `0.9.x`를 받으세요. Linux x86_64는 AppImage/deb, Windows x64는 설치 프로그램/포터블, Apple Silicon macOS는 dmg/zip입니다. 패키지는 아직 코드 서명·공증되지 않았고, Intel Mac 빌드는 포함되지 않습니다. 먼저 [설치 및 로컬 데이터 보안](docs/installing-and-security.md)을 읽으세요.
+
+소스에서 실행:
+
+```bash
+npm install
+npm run dev
+```
+
+## 문서
+
+| 여기서 시작 | CanvasTTY 확장 |
+|:--|:--|
+| [문서 허브](docs/README.md) | [위젯 작성](docs/widget-authoring.md) |
+| [시작하기](docs/getting-started.md) | [메트릭과 텔레메트리](docs/metrics-and-telemetry.md) |
+| [설치, 릴리스, 로컬 데이터](docs/installing-and-security.md) | [보안 정책](SECURITY.md) |
+| [아키텍처](docs/ARCHITECTURE.md) | [UI 계약](docs/UI_CONTRACT.md) |
+
+> CanvasTTY는 현재 Electron MVP입니다. 커스텀 위젯은 소스 수준 확장이며, 런타임 플러그인 레지스트리는 아직 없습니다.
+
+## 빠른 검사
+
+```bash
+npm test
+npm run typecheck
+npm run build
+```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 <p align="center">
   <a href="README.md"><strong>English</strong></a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.pt-BR.md">Português</a> ·
   <a href="README.ru.md">Русский</a> ·
   <a href="README.zh-CN.md">简体中文</a>
 </p>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,64 @@
+<p align="center">
+  <img src="docs/assets/canvastty-cover.png" alt="CanvasTTY — um desktop espacial para terminais locais e agentes de IA" width="100%">
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.pt-BR.md"><strong>Português</strong></a> ·
+  <a href="README.ru.md">Русский</a> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<table>
+  <tr>
+    <td>
+      <strong>Seus terminais são lugares, não abas.</strong><br>
+      CanvasTTY é um desktop espacial em Electron para PTYs locais reais e sessões CLI de agentes de IA. Zona Home fixa, terminais ao vivo em um canvas infinito e limites de provedores com base em fontes de dados reais.
+    </td>
+  </tr>
+</table>
+
+## Stack
+
+| Desktop | Interface | Terminal | Provedores |
+|:--|:--|:--|:--|
+| **Electron**<br>electron-vite | **React**<br>TypeScript | **xterm.js**<br>node-pty | **Codex**<br>Claude · Kimi |
+
+## Um canvas, sessões reais
+
+Inicie um shell ou agente no diretório do projeto, mova e redimensione o terminal ao vivo, afaste o zoom para navegar semanticamente e volte ao Home para sessões, limites, mídia e atalhos de lançamento. O CanvasTTY mantém o estado do PTY no processo main confiável e expõe ao renderer apenas capacidades tipadas e na lista de permissões.
+
+## Instalação
+
+Baixe a prévia pública `0.9.x` em [GitHub Releases](https://github.com/howdeploy/CanvasTTY/releases): AppImage/deb para Linux x86_64, instalador/portable para Windows x64 e dmg/zip para macOS Apple Silicon. Os pacotes ainda não são assinados nem notariados; builds para Intel Mac ainda não estão incluídas. Leia [instalação e segurança de dados locais](docs/installing-and-security.md).
+
+Ou execute a partir do código-fonte:
+
+```bash
+npm install
+npm run dev
+```
+
+## Documentação
+
+| Comece aqui | Estenda o CanvasTTY |
+|:--|:--|
+| [Hub de documentação](docs/README.md) | [Criação de widgets](docs/widget-authoring.md) |
+| [Primeiros passos](docs/getting-started.md) | [Métricas e telemetria](docs/metrics-and-telemetry.md) |
+| [Instalação, releases e dados locais](docs/installing-and-security.md) | [Política de segurança](SECURITY.md) |
+| [Arquitetura](docs/ARCHITECTURE.md) | [Contrato de UI](docs/UI_CONTRACT.md) |
+
+> O CanvasTTY é atualmente um MVP em Electron. Widgets personalizados são extensões no nível do código-fonte; ainda não há registro de plugins em runtime.
+
+## Verificações rápidas
+
+```bash
+npm test
+npm run typecheck
+npm run build
+```

--- a/README.ru.md
+++ b/README.ru.md
@@ -4,6 +4,12 @@
 
 <p align="center">
   <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.pt-BR.md">Português</a> ·
   <a href="README.ru.md"><strong>Русский</strong></a> ·
   <a href="README.zh-CN.md">简体中文</a>
 </p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,12 @@
 
 <p align="center">
   <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.pt-BR.md">Português</a> ·
   <a href="README.ru.md">Русский</a> ·
   <a href="README.zh-CN.md"><strong>简体中文</strong></a>
 </p>


### PR DESCRIPTION
## What
Adds root sibling README locales for popular languages, matching the existing `ru` / `zh-CN` pattern:

| File | Language |
|------|----------|
| `README.es.md` | Español |
| `README.de.md` | Deutsch |
| `README.fr.md` | Français |
| `README.ja.md` | 日本語 |
| `README.ko.md` | 한국어 |
| `README.pt-BR.md` | Português (Brasil) |

Also expands the language switcher in `README.md`, `README.ru.md`, and `README.zh-CN.md`.

## Why
Help non-English speakers discover CanvasTTY from the repo landing page.

## Scope notes
- **Docs-only** — no code changes.
- New locales link deeper docs to **English** paths until translated docs exist.
- Product names, CLI commands, and provider names stay in English.

## How to test
1. Preview each new `README.*.md` on GitHub.
2. Click language bar links (current language bold).
3. Confirm cover image and install/dev commands match the English README.