### PR TITLE
fix: ignore linked-worktree .git metadata in secret audit

### DIFF
--- a/scripts/audit-secrets.mjs
+++ b/scripts/audit-secrets.mjs
@@ -3,7 +3,7 @@ import { extname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PROJECT_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const IGNORED_DIRECTORIES = new Set([
+const IGNORED_ENTRY_NAMES = new Set([
   ".git",
   ".agents",
   ".codex",
@@ -74,7 +74,11 @@ async function walk(directory) {
   const files = [];
 
   for (const entry of entries) {
-    if (entry.isDirectory() && IGNORED_DIRECTORIES.has(entry.name)) continue;
+    // In a normal clone .git is a directory; in a Git worktree it is a file
+    // containing an absolute gitdir path. Both forms are repository metadata,
+    // not publishable project content, so skip the entry before inspecting type.
+    if (IGNORED_ENTRY_NAMES.has(entry.name)) continue;
+
     const path = resolve(directory, entry.name);
     if (entry.isDirectory()) files.push(...await walk(path));
     else if (entry.isFile()) files.push(path);

--- a/tests/repository-security.test.mjs
+++ b/tests/repository-security.test.mjs
@@ -1,10 +1,35 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { collectRepositoryIssues } from "../scripts/audit-secrets.mjs";
 
 test("publishable repository files contain no high-confidence secrets or personal paths", async () => {
   assert.deepEqual(await collectRepositoryIssues(), []);
+});
+
+test("secret audit ignores the Git metadata file used by linked worktrees", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "canvastty-secret-audit-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const privateGitDir = `/${["home", "local-user", "repo", ".git", "worktrees", "workspace"].join("/")}`;
+  await writeFile(join(root, ".git"), `gitdir: ${privateGitDir}\n`, "utf8");
+  await writeFile(join(root, "README.md"), "publishable content\n", "utf8");
+
+  assert.deepEqual(await collectRepositoryIssues(root), []);
+});
+
+test("secret audit still reports personal paths in publishable files", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "canvastty-secret-audit-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const privatePath = `/${["home", "local-user", "project"].join("/")}/`;
+  await writeFile(join(root, "notes.md"), `Local path: ${privatePath}\n`, "utf8");
+
+  assert.deepEqual(await collectRepositoryIssues(root), [
+    { path: "notes.md", rule: "personal home path" }
+  ]);
 });
 
 test("gitignore excludes local credentials, logs, builds, and agent context", async () => {


### PR DESCRIPTION
Fixes #8.

## Summary

- ignore repository metadata entries by name before inspecting their file type;
- handle both normal-clone `.git/` directories and linked-worktree `.git` files;
- add regression coverage confirming that linked-worktree metadata is ignored;
- preserve detection of personal paths in ordinary publishable files.

## Why

In a linked Git worktree, `.git` is a regular text file containing an absolute
`gitdir` path. The previous walker only applied the ignore list to directories,
so that metadata file was scanned and triggered the existing personal-path rule.

The fix does not weaken the detector. It skips repository metadata before type
inspection and separately verifies that the same path remains detectable in a
normal project file.

## Scope

Only these files are changed:

- `scripts/audit-secrets.mjs`
- `tests/repository-security.test.mjs`