### PR TITLE
fix(release): produce verifiable ad-hoc macOS bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,6 @@ jobs:
             script: package:mac
             artifact: canvastty-macos
     runs-on: ${{ matrix.runner }}
-    env:
-      CSC_IDENTITY_AUTO_DISCOVERY: "false"
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -47,6 +45,12 @@ jobs:
         run: npm test
       - name: Build installers
         run: npm run ${{ matrix.script }}
+      - name: Verify macOS app signature
+        if: runner.os == 'macOS'
+        run: |
+          app="$(find release -type d -name 'CanvasTTY.app' -print -quit)"
+          test -n "$app"
+          codesign --verify --deep --strict --verbose=4 "$app"
       - name: Install AppImage runtime dependency
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libfuse2t64

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -64,6 +64,12 @@ portable:
 mac:
   icon: build/icon.png
   category: public.app-category.developer-tools
+  # A free distribution has no Developer ID identity. Sign the bundle explicitly
+  # with an ad-hoc identity so macOS can verify its contents are internally
+  # consistent; Gatekeeper still requires a one-time user acknowledgement.
+  identity: "-"
+  hardenedRuntime: false
+  notarize: false
   target:
     - dmg
     - zip

--- a/tests/repository-security.test.mjs
+++ b/tests/repository-security.test.mjs
@@ -95,6 +95,23 @@ test("release workflow uploads installers only and keeps Windows targets distinc
   }
 });
 
+test("macOS release artifacts are ad-hoc signed and verified before upload", async () => {
+  const config = normalizeLineEndings(
+    await readFile(new URL("../electron-builder.yml", import.meta.url), "utf8")
+  );
+  const workflow = normalizeLineEndings(
+    await readFile(new URL("../.github/workflows/release.yml", import.meta.url), "utf8")
+  );
+
+  assert.match(config, /^mac:\n(?:[\s\S]*?)^  identity: "-"$/m);
+  assert.match(config, /^  hardenedRuntime: false$/m);
+  assert.match(config, /^  notarize: false$/m);
+  assert.doesNotMatch(workflow, /^\s+CSC_IDENTITY_AUTO_DISCOVERY:/m);
+  assert.match(workflow, /Verify macOS app signature/);
+  assert.match(workflow, /codesign --verify --deep --strict --verbose=4/);
+  assert.ok(workflow.indexOf("Verify macOS app signature") < workflow.indexOf("Upload installers"));
+});
+
 test("AppImage avoids maximum XZ compression and is smoke-tested before upload", async () => {
   const config = normalizeLineEndings(
     await readFile(new URL("../electron-builder.yml", import.meta.url), "utf8")


### PR DESCRIPTION
## Summary

- explicitly sign macOS DMG and ZIP bundles with the ad-hoc identity, without Apple credentials
- disable hardened runtime and notarization for this free distribution path
- verify the packaged `.app` with strict `codesign` before artifacts are uploaded
- lock the release contract with a focused repository test

## Verification

- `npm test` — 360 passing tests
- `npm run package:mac`
- `codesign --verify --deep --strict --verbose=4 release/mac-arm64/CanvasTTY.app`
- `hdiutil verify release/CanvasTTY-1.2.3-mac-arm64.dmg`
- manual Apple Silicon install and launch: passed

The bundle is deliberately ad-hoc signed: users may still need to acknowledge the unknown-developer prompt. This does not provide Developer ID signing or notarization, so the full production-signing work in #18 remains open.

Refs #18