### PR TITLE
Fix launcher clipboard parsing for GNOME file managers

### DIFF
--- a/src/renderer/src/features/launcher/AgentLaunchDialog.tsx
+++ b/src/renderer/src/features/launcher/AgentLaunchDialog.tsx
@@ -8,6 +8,7 @@ import { ProviderIcon } from "../../components/ProviderIcon";
 import { UiIcon } from "../../components/UiIcon";
 import { t } from "../../lib/i18n";
 import { PROVIDERS } from "../../lib/providers";
+import { directoryPathFromClipboard } from "../../lib/directoryPathFromClipboard";
 
 interface AgentLaunchDialogProps {
   provider: AgentProviderId | null;
@@ -15,33 +16,6 @@ interface AgentLaunchDialogProps {
   onClose(): void;
   onAcknowledge(provider: AgentProviderId): Promise<void>;
   onLaunch(provider: AgentProviderId, profile: LaunchProfileId, cwd: string): Promise<void>;
-}
-
-export function directoryPathFromClipboard(text: string): string | null {
-  let path = text.trim();
-  if (!path) return null;
-
-  // Finder and file managers may expose copied folders as a URI list.
-  if (path.includes("\n") || path.includes("\r")) {
-    path = path.split(/\r?\n/).map((line) => line.trim()).find((line) => line && !line.startsWith("#")) ?? "";
-  }
-  if ((path.startsWith('"') && path.endsWith('"')) || (path.startsWith("'") && path.endsWith("'"))) {
-    path = path.slice(1, -1).trim();
-  }
-  if (!path) return null;
-
-  if (path.toLowerCase().startsWith("file://")) {
-    try {
-      const url = new URL(path);
-      const decodedPath = decodeURIComponent(url.pathname);
-      path = url.hostname ? `//${url.hostname}${decodedPath}` : decodedPath;
-      if (/^\/[a-zA-Z]:\//.test(path)) path = path.slice(1);
-    } catch {
-      return null;
-    }
-  }
-
-  return path || null;
 }
 
 export function AgentLaunchDialog({

--- a/src/renderer/src/lib/directoryPathFromClipboard.ts
+++ b/src/renderer/src/lib/directoryPathFromClipboard.ts
@@ -1,0 +1,25 @@
+export function directoryPathFromClipboard(text: string): string | null {
+  // Select a path, skipping URI-list comments and file-manager metadata.
+  const paths = text.split(/\r\n|[\r\n]/).map((line) => {
+    let path = line.trim();
+    if ((path.startsWith('"') && path.endsWith('"')) || (path.startsWith("'") && path.endsWith("'"))) {
+      path = path.slice(1, -1).trim();
+    }
+    return path;
+  });
+  let path = paths.find((line) => /^(?:\/|file:\/\/|[a-z]:[\\/]|\\\\|~\/)/i.test(line));
+  if (!path) return null;
+
+  if (path.toLowerCase().startsWith("file://")) {
+    try {
+      const url = new URL(path);
+      const decodedPath = decodeURIComponent(url.pathname);
+      path = url.hostname ? `//${url.hostname}${decodedPath}` : decodedPath;
+      if (/^\/[a-zA-Z]:\//.test(path)) path = path.slice(1);
+    } catch {
+      return null;
+    }
+  }
+
+  return path || null;
+}

--- a/tests/agent-launch-dialog.test.mjs
+++ b/tests/agent-launch-dialog.test.mjs
@@ -9,7 +9,6 @@ test("agent launcher can import its project path from the clipboard", async () =
 
   assert.match(source, /window\.canvasTTY\.clipboard\.readText\(\)/);
   assert.match(source, /directoryPathFromClipboard/);
-  assert.match(source, /file:\/\//);
   assert.match(source, /folder-field__paste/);
   assert.match(source, /aria-label=\{t\(locale, "pasteProjectPath"\)\}/);
 });

--- a/tests/directory-path-from-clipboard.test.mjs
+++ b/tests/directory-path-from-clipboard.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { directoryPathFromClipboard } from "../src/renderer/src/lib/directoryPathFromClipboard.ts";
+
+test("skips GNOME clipboard markers and copy/cut verbs", () => {
+  for (const verb of ["copy", "cut"]) {
+    for (const newline of ["\n", "\r\n", "\r"]) {
+      assert.equal(directoryPathFromClipboard([
+        "x-special/nautilus-clipboard", verb, "file:///home/runner/project"
+      ].join(newline)), "/home/runner/project");
+    }
+  }
+});
+
+test("selects the first path from URI lists and ignores comments and metadata", () => {
+  assert.equal(directoryPathFromClipboard("# folders\n\ncopy\nfile:///first\nfile:///second"), "/first");
+  assert.equal(directoryPathFromClipboard("metadata\n/home/runner/project\n/second"), "/home/runner/project");
+  assert.equal(directoryPathFromClipboard("copy\n\"/home/runner/my project\""), "/home/runner/my project");
+});
+
+test("strips paired quotes and preserves spaces in paths", () => {
+  for (const quote of ['"', "'"]) {
+    assert.equal(directoryPathFromClipboard(`  ${quote}/my project${quote}  `), "/my project");
+  }
+  assert.equal(directoryPathFromClipboard("/my project"), "/my project");
+});
+
+test("accepts Windows drive paths and UNC paths", () => {
+  assert.equal(directoryPathFromClipboard("C:\\Users\\me\\project"), "C:\\Users\\me\\project");
+  assert.equal(directoryPathFromClipboard("copy\nD:/project"), "D:/project");
+  assert.equal(directoryPathFromClipboard("\\\\server\\share\\project"), "\\\\server\\share\\project");
+});
+
+test("decodes file URLs including Windows drives and network shares", () => {
+  assert.equal(directoryPathFromClipboard('"file:///home/my%20project"'), "/home/my project");
+  assert.equal(directoryPathFromClipboard("FILE:///C:/my%20project"), "C:/my project");
+  assert.equal(directoryPathFromClipboard("file://server/share/my%20project"), "//server/share/my project");
+});
+
+test("rejects empty, metadata-only, non-path, and malformed URL payloads", () => {
+  for (const text of ["", "  ", "''", "x-special/nautilus-clipboard\ncopy", "# /comment", "hello", "https://example.com", "file:///bad%zz", "file://["]) {
+    assert.equal(directoryPathFromClipboard(text), null, text);
+  }
+});


### PR DESCRIPTION
GNOME clipboard payloads begin with a marker and a copy/cut verb, which the launcher previously selected as the project directory. Select the first path-looking line so these payloads resolve to the actual directory.

Follow-up to the review on #27, which has already merged. Extract the parser into `src/renderer/src/lib/` and add behavioral coverage for GNOME copy/cut payloads, line endings, paired quotes, URI lists, Windows drive/UNC paths, percent-decoding, and invalid input.

Validation on 994e18b: `npm test` (542 passed), `npm run typecheck`, and `npm run build` all pass locally.

The optional home-directory expansion and paste-icon follow-ups remain deferred; no suitable paste icon exists in the vendored Lucide assets.
